### PR TITLE
Performance

### DIFF
--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -4,8 +4,8 @@ Utility for calculating sun position, pitch angle and values related to roll.
 """
 from math import acos, asin, atan2, cos, degrees, pi, radians, sin
 
+import numba
 import numpy as np
-import Ska.quatutil
 from astropy.table import Table
 from Chandra.Time import DateTime
 from chandra_aca.transform import radec_to_eci
@@ -230,28 +230,49 @@ def sph_dist(a1, d1, a2, d2):
     return degrees(acos(val))
 
 
-def pitch(ra, dec, time):
-    """Calculate sun pitch angle for the given spacecraft attitude ``ra``,
-    ``dec`` at ``time``.
+def pitch(ra, dec, time=None, sun_ra=None, sun_dec=None):
+    """Calculate sun pitch angle for spacecraft attitude ``ra``, ``dec``.
+
+    You can provide either ``time`` or explicit values of ``sun_ra`` and ``sun_dec``.
 
     Example::
 
      >>> ska_sun.pitch(10., 20., '2009:001:00:01:02')
      96.256434327840864
 
-    :param ra: right ascension
-    :param dec: declination
-    :param time: time (any Chandra.Time format)
+    :param ra: target right ascension (deg)
+    :param dec: target declination (deg)
+    :param time: time (CxoTimeLike) [optional]
+    :param sun_ra: sun RA (deg) instead of time [optional]
+    :param sun_dec: sun Dec (deg) instead of time [optional]
 
     :returns: sun pitch angle (deg)
     """
-    sun_ra, sun_dec = position(time)
+    if time is not None:
+        sun_ra, sun_dec = position(time)
     pitch = sph_dist(ra, dec, sun_ra, sun_dec)
 
     return pitch
 
 
-def nominal_roll(ra, dec, time=None, sun_ra=None, sun_dec=None):
+@numba.njit
+def _radec2eci(ra, dec):
+    """
+    Convert from RA,Dec to ECI for single RA,Dec pair.
+
+    This is a numba-ized version of the original code in Ska.quatutil.
+
+    :param ra: Right Ascension (degrees)
+    :param dec: Declination (degrees)
+    :returns: numpy array ECI (3-vector)
+    """
+    r = np.radians(ra)
+    d = np.radians(dec)
+    return np.array([np.cos(r) * np.cos(d), np.sin(r) * np.cos(d), np.sin(d)])
+
+
+@numba.njit
+def nominal_roll(ra, dec, sun_ra, sun_dec):
     """Calculate nominal roll angle for the given spacecraft attitude ``ra``,
     ``dec`` at ``time``.  Optionally one can provide explicit values of
     ``sun_ra`` and ``sun_dec`` instead of ``time``.
@@ -270,10 +291,10 @@ def nominal_roll(ra, dec, time=None, sun_ra=None, sun_dec=None):
     :returns: nominal roll angle (deg)
 
     """
-    if time is not None:
-        sun_ra, sun_dec = position(time)
-    sun_eci = Ska.quatutil.radec2eci(sun_ra, sun_dec)
-    body_x = Ska.quatutil.radec2eci(ra, dec)
+    # if time is not None:
+    #    sun_ra, sun_dec = position(time)
+    sun_eci = _radec2eci(sun_ra, sun_dec)
+    body_x = _radec2eci(ra, dec)
     if np.sum((sun_eci - body_x) ** 2) < 1e-10:
         raise ValueError("No nominal roll for ra, dec == sun_ra, sun_dec")
     body_y = np.cross(body_x, sun_eci)
@@ -282,11 +303,11 @@ def nominal_roll(ra, dec, time=None, sun_ra=None, sun_dec=None):
     body_z = body_z / np.sqrt(
         np.sum(body_z**2)
     )  # shouldn't be needed but do it anyway
-    q_att = Quat(np.array([body_x, body_y, body_z]).transpose())
-    return q_att.roll
+    roll = np.degrees(np.arctan2(body_y[2], body_z[2]))
+    return roll
 
 
-def off_nominal_roll(att, time):
+def off_nominal_roll(att, sun_ra=None, sun_dec=None):
     """
     Calculate off-nominal roll angle for the given spacecraft attitude ``att``, at
     ``time``.  Off-nominal roll is defined as roll - nominal roll.
@@ -299,14 +320,16 @@ def off_nominal_roll(att, time):
 
     :param att: any Quat() value (e.g. [ra, dec, roll] or [q1, q2, q3, q4])
     :param time: any DateTime value
+    :param sun_ra: sun RA (deg) instead of time [optional]
+    :param sun_dec: sun Dec (deg) instead of time [optional]
 
     :returns: off nominal roll angle (deg)
     """
 
-    q = Quat(att)
+    q = att if isinstance(att, Quat) else Quat(att)
     roll = q.roll
 
-    nom_roll = nominal_roll(q.ra, q.dec, time)
+    nom_roll = nominal_roll(q.ra, q.dec, sun_ra, sun_dec)
     off_nom_roll = roll - nom_roll
 
     if off_nom_roll < -180:

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -132,7 +132,7 @@ def position(time):
     return out
 
 
-@numba.njit
+@numba.njit(cache=True)
 def position_at_jd(jd):
     t = (jd - 2415020) / (36525.0)
 
@@ -210,7 +210,7 @@ def position_at_jd(jd):
     return ra / dtor, dec / dtor
 
 
-@numba.njit
+@numba.njit(cache=True)
 def sph_dist(a1, d1, a2, d2):
     """Calculate spherical distance between two sky positions.
 
@@ -263,7 +263,7 @@ def pitch(ra, dec, time=None, sun_ra=None, sun_dec=None):
     return pitch
 
 
-@numba.njit
+@numba.njit(cache=True)
 def _radec2eci(ra, dec):
     """
     Convert from RA,Dec to ECI for single RA,Dec pair.
@@ -304,7 +304,7 @@ def nominal_roll(ra, dec, time=None, sun_ra=None, sun_dec=None):
     return roll
 
 
-@numba.njit
+@numba.njit(cache=True)
 def _nominal_roll(ra, dec, sun_ra, sun_dec):
     sun_eci = _radec2eci(sun_ra, sun_dec)
     body_x = _radec2eci(ra, dec)


### PR DESCRIPTION
## Description

This is part of a set of performance changes to kadi, chandra_aca, ska_sun, Quaternion, and Chandra.Maneuver to make kadi command states faster.  The changes are independent.

This PR includes changes to:

- Use numba - including a numba-ized version of the radec2eci from Ska.quatutil
- Add support for sun_ra, sun_dec kwargs to the pitch and off_nominal_roll functions to allow upstream applications (with values for those) to run faster.
- Use numba caching


## Interface impacts
The numba cache uses the NUMBA_CACHE_DIR already configured in ska after https://github.com/sot/ska_helpers/pull/29 .
The pitch and off_nominal_roll functions now support sun_ra and sun_dec kwargs.


## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (as of  6e2d783)

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Also checking numba caching behavior in ska3-flight 2023.3. This demonstrates the creation of numba cache files in the expected user directory.
```
(ska3) ➜  ska_sun git:(performance) rm -rf ~/.ska3             
(ska3) ➜  ska_sun git:(performance) pytest ska_sun
============================= test session starts ==============================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 12 items                                                             

ska_sun/tests/test_sun.py ............                                   [100%]

============================== 12 passed in 6.95s ==============================
(ska3) ➜  ska_sun git:(performance) find ~/.ska3     
/Users/aldcroft/.ska3
/Users/aldcroft/.ska3/cache
/Users/aldcroft/.ska3/cache/numba
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun.position_at_jd-135.py310.1.nbc
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun._nominal_roll-307.py310.nbi
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun.sph_dist-213.py310.nbi
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun._radec2eci-266.py310.nbi
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun._nominal_roll-307.py310.1.nbc
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun.position_at_jd-135.py310.nbi
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun._radec2eci-266.py310.1.nbc
/Users/aldcroft/.ska3/cache/numba/ska_sun_28343af752654d47d93a0d0bcdf944cc27778384/sun.sph_dist-213.py310.1.nbc
```

With regard to performance, on linux (HEAD fido) a comparison with ska_sun 3.10.1 shows the expected result that the numba caching can be slower on the first run of a function (compared to flight / 3.10.1) and then has advantages.  

flight:
```
In [1]: import ska_sun

In [2]: time = '2023:001'

In [3]: %time ska_sun.nominal_roll(10, 20, time=time)
CPU times: user 4.83 ms, sys: 0 ns, total: 4.83 ms
Wall time: 6.41 ms
Out[3]: 292.1368992773556

# This is the version without performance improvements but it still shows some speedup when called again (NFS caching?)
In [4]: %time ska_sun.nominal_roll(10, 20, time=time)
CPU times: user 883 µs, sys: 0 ns, total: 883 µs. 
Wall time: 812 µs                      
Out[4]: 292.1368992773556

In [6]: %timeit ska_sun.nominal_roll(10, 20, time=time)
417 µs ± 118 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [7]: ska_sun.__version__
Out[7]: '3.10.1'
```

This PR
```
In [1]: import ska_sun

In [2]: time = '2023:001'

In [3]: %time ska_sun.nominal_roll(10, 20, time=time)
CPU times: user 1.92 s, sys: 43.8 ms, total: 1.96 s
Wall time: 2.31 s
Out[3]: -67.86310072264433

In [4]: %time ska_sun.nominal_roll(10, 20, time=time)
CPU times: user 123 µs, sys: 10 µs, total: 133 µs
Wall time: 136 µs
Out[4]: -67.86310072264433

In [5]: %timeit ska_sun.nominal_roll(10, 20, time=time)
35.3 µs ± 1.86 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

And when set with debug printing on the numba caching, the caching saves seem reasonable
```
ska3-jeanconn-fido> export NUMBA_DEBUG_CACHE=1
ska3-jeanconn-fido> ipython
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:26:04) [GCC 10.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import ska_sun

In [2]: time = '2023:001'

In [3]: %time ska_sun.nominal_roll(10, 20, time=time)
[cache] index saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun.position_at_jd-135.py310.nbi'
[cache] data saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun.position_at_jd-135.py310.1.nbc'
[cache] index saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._radec2eci-266.py310.nbi'
[cache] data saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._radec2eci-266.py310.1.nbc'
[cache] index loaded from '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._radec2eci-266.py310.nbi'
[cache] index loaded from '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._radec2eci-266.py310.nbi'
[cache] index saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._radec2eci-266.py310.nbi'
[cache] data saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._radec2eci-266.py310.2.nbc'
[cache] index saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._nominal_roll-307.py310.nbi'
[cache] data saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun._nominal_roll-307.py310.1.nbc'
CPU times: user 1.91 s, sys: 40.1 ms, total: 1.95 s
Wall time: 2.3 s
Out[3]: -67.86310072264433

In [4]: %time ska_sun.nominal_roll(10, 20, time=time)
CPU times: user 169 µs, sys: 16 µs, total: 185 µs
Wall time: 189 µs
Out[4]: -67.86310072264433

In [5]: %time ska_sun.nominal_roll(10, 20, time=time)
CPU times: user 159 µs, sys: 16 µs, total: 175 µs
Wall time: 178 µs
Out[5]: -67.86310072264433

In [6]: %time ska_sun.pitch(10, 20, time=time)
[cache] index saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun.sph_dist-213.py310.nbi'
[cache] data saved to '/home/jeanconn/.ska3/cache/numba/ska_sun_cdeca1941b46e08ad13896c2df292287d50c752d/sun.sph_dist-213.py310.1.nbc'
CPU times: user 84.7 ms, sys: 136 µs, total: 84.8 ms
Wall time: 93.8 ms
Out[6]: 96.6598242368135

In [7]: %time ska_sun.pitch(10, 20, time=time)
CPU times: user 119 µs, sys: 11 µs, total: 130 µs
Wall time: 133 µs
Out[7]: 96.6598242368135

```

And as mentioned, this PR provides the option to supply sun_ra and sun_dec from the calling code which can provide significant savings.

```
In [8]: %timeit ska_sun.nominal_roll(10, 20, sun_ra=sun_ra, sun_dec=sun_dec)
1.21 µs ± 0.62 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

