### PR TITLE
Support multiple sun position dispatch methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.7.0
     hooks:
     - id: black
 

--- a/ska_sun/__init__.py
+++ b/ska_sun/__init__.py
@@ -2,6 +2,7 @@
 
 import ska_helpers
 
+from .config import conf  # noqa
 from .sun import *  # noqa
 
 __version__ = ska_helpers.get_version("ska_sun")

--- a/ska_sun/config.py
+++ b/ska_sun/config.py
@@ -1,0 +1,30 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Configuration for ska_sun.
+
+See https://docs.astropy.org/en/stable/config/index.html#customizing-config-location-in-affiliated-packages
+and https://github.com/astropy/astropy/issues/12960.
+"""  # noqa
+
+from astropy import config
+from astropy.config import ConfigNamespace
+
+
+class ConfigItem(config.ConfigItem):
+    rootname = "ska_sun"
+
+
+class Conf(ConfigNamespace):
+    """
+    Configuration parameters for ska_sun.
+    """
+
+    sun_position_method_default = ConfigItem(
+        ["fast", "accurate"],
+        'Default value of `method` parameter in ska_sun.position() (default="fast").',
+    )
+
+
+# Create a configuration instance for the user
+conf = Conf()

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -13,17 +13,6 @@ from chandra_aca.transform import eci_to_radec, radec_to_eci
 from Quaternion import Quat
 from ska_helpers import chandra_models
 
-__all__ = [
-    "allowed_rolldev",
-    "apply_sun_pitch_yaw",
-    "get_sun_pitch_yaw",
-    "load_roll_table",
-    "nominal_roll",
-    "off_nominal_roll",
-    "pitch",
-    "position",
-    "sph_dist",
-]
 
 CHANDRA_MODELS_PITCH_ROLL_FILE = "chandra_models/pitch_roll/pitch_roll_constraint.csv"
 
@@ -36,6 +25,7 @@ __all__ = [
     "position_accurate",
     "sph_dist",
     "pitch",
+    "load_roll_table",
     "nominal_roll",
     "off_nominal_roll",
     "get_sun_pitch_yaw",

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -13,9 +13,9 @@ from chandra_aca.transform import eci_to_radec, radec_to_eci
 from Quaternion import Quat
 from ska_helpers import chandra_models
 
-CHANDRA_MODELS_PITCH_ROLL_FILE = "chandra_models/pitch_roll/pitch_roll_constraint.csv"
-
 from . import conf
+
+CHANDRA_MODELS_PITCH_ROLL_FILE = "chandra_models/pitch_roll/pitch_roll_constraint.csv"
 
 __all__ = [
     "allowed_rolldev",

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -134,16 +134,17 @@ def position_fast(time):
     Code modified from http://idlastro.gsfc.nasa.gov/ftp/pro/astro/sunpos.pro
 
     This implementation is returns coordinates that are in error by as much as
-    0.3 deg. Use the ``position()`` function unless speed is critical.
+    0.3 deg. Use the ``position_accurate()`` function or ``position(.., method='accurate')``
+    unless speed is critical.
 
-    This function is about 40x faster than the ``position()`` function (30 us for a
-    single time vs 1.2 ms). However, the ``position()`` function can be vectorized and
+    This function is about 40x faster than the ``position_accurate()`` function (30 us for a
+    single time vs 1.2 ms). However, the ``position_accurate()`` function can be vectorized and
     the speed difference is reduced.
 
     Example::
 
      >>> import ska_sun
-     >>> ska_sun.position('2008:002:00:01:02')
+     >>> ska_sun.position_fast('2008:002:00:01:02')
      (281.90344855695275, -22.9892737322084)
 
     :param time: Input time (Chandra.Time compatible format)

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -13,7 +13,6 @@ from chandra_aca.transform import eci_to_radec, radec_to_eci
 from Quaternion import Quat
 from ska_helpers import chandra_models
 
-
 CHANDRA_MODELS_PITCH_ROLL_FILE = "chandra_models/pitch_roll/pitch_roll_constraint.csv"
 
 from . import conf
@@ -256,11 +255,25 @@ def position(time, method=None, **kwargs):
     """
     Calculate the sun RA, Dec at the given ``time`` from Earth geocenter or Chandra.
 
+    The method for position determination may be explicitly set via kwarg to ``fast`` or
+    ``accurate``.  See `position_fast()` and `position_accurate` methods for details.
+    The default method behavior is set by ``ska_sun.conf.sun_position_method_default``,
+    currently set to `fast`.
+
+    The ``accurate`` method also supports the ``from_chandra`` kwarg.
+
     Example::
 
      >>> import ska_sun
      >>> ska_sun.position('2008:002:00:01:02')
+     (281.90344855695275, -22.9892737322084)
+     >>> ska_sun.position('2008:002:00:01:02', method='accurate')
      (281.7865848220755, -22.99607130644057)
+     >>> with ska_sun.conf.set_temp('sun_position_method_default', 'accurate'):
+     ...    ska_sun.position('2008:002:00:01:02')
+     (281.7865848220755, -22.99607130644057
+     >>> ska_sun.position('2008:002:00:01:02', method='accurate', from_chandra=True)
+     (281.80963749492935, -23.033877980418676)
 
     :param time: Input time(s) (CxoTimeLike)
     :param method: Method to use ("fast" | "accurate", default="fast")


### PR DESCRIPTION
## Description

The legacy "fast" method of computing the sun RA, Dec from the Earth geocenter appears to have errors up to about 0.3 deg. For many applications this is fine, but for cases where this is not OK this PR adds a new more accurate method which uses the DE432s ephemeris.

Fixes #2.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Added new unit test to do some rough functional testing against data in obsid 17198.
