### PR TITLE
Fix a test fail from numerical issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,14 @@
+default_language_version:
+    python: python3
+
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     - id: black
-      language_version: python3.11
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/ska_sun/tests/test_sun.py
+++ b/ska_sun/tests/test_sun.py
@@ -15,7 +15,6 @@ from ..sun import position
 
 
 def test_allowed_rolldev():
-
     # Test array of pitchs and allowed roll dev
     testarr = [
         [135, 13.979],
@@ -87,13 +86,13 @@ def test_apply_sun_pitch_yaw_with_grid():
     """Use np.ogrid to make a grid of RA/Dec values (via dpitches and dyaws)"""
     dpitches, dyaws = np.ogrid[0:-3:2j, -5:5:3j]
     atts = apply_sun_pitch_yaw(
-        att=[0, 45, 10], pitch=dpitches, yaw=dyaws, sun_ra=0, sun_dec=90
+        att=[1, 45, 10], pitch=dpitches, yaw=dyaws, sun_ra=0, sun_dec=90
     )
     assert atts.shape == (2, 3)
     exp = np.array(
         [
-            [[355.0, 45.0, 10.0], [360.0, 45.0, 10.0], [5.0, 45.0, 10.0]],
-            [[355.0, 48.0, 10.0], [0.0, 48.0, 10.0], [5.0, 48.0, 10.0]],
+            [[356.0, 45.0, 10.0], [1.0, 45.0, 10.0], [6.0, 45.0, 10.0]],
+            [[356.0, 48.0, 10.0], [1.0, 48.0, 10.0], [6.0, 48.0, 10.0]],
         ]
     )
     assert np.allclose(atts.equatorial, exp)


### PR DESCRIPTION
## Description

@jeanconn noticed tests failing in ska3-prime on linux. The test was poorly written and was failing due to floating point differences between fido and Mac and probably kady.

This also fixes the pre-commit to update to the most recent black and isort versions.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux - (ska3 flight and ska3-prime on fido)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
