### PR TITLE
Allow repeated pitch vals and make unit tests work after chandra_models updates

### DIFF
--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -11,33 +11,48 @@ from Chandra.Time import DateTime
 from chandra_aca.transform import radec_to_eci
 from Quaternion import Quat
 from ska_helpers import chandra_models
-from ska_helpers.utils import LazyVal
+
+__all__ = [
+    "allowed_rolldev",
+    "apply_sun_pitch_yaw",
+    "get_sun_pitch_yaw",
+    "load_roll_table",
+    "nominal_roll",
+    "off_nominal_roll",
+    "pitch",
+    "position",
+    "sph_dist",
+]
 
 CHANDRA_MODELS_PITCH_ROLL_FILE = "chandra_models/pitch_roll/pitch_roll_constraint.csv"
 
 
+def _roll_table_read_func(filename):
+    return Table.read(filename), filename
+
+
+@chandra_models.chandra_models_cache
 def load_roll_table():
-    """Load the pitch/roll table from the chandra_models repo."""
+    """Load the pitch/roll table from the chandra_models repo.
 
-    def read_func(filename):
-        return Table.read(filename), filename
+    The result depends on environment variables:
 
+    - ``CHANDRA_MODELS_REPO_DIR``: root directory of chandra_models repo
+    - ``CHANDRA_MODELS_DEFAULT_VERSION``: default version of chandra_models to use
+
+    :returns: ``astropy.table.Table``
+        Table with "pitch" and "off_nom_roll" columns. Detailed provenance information
+        is available in the table ``meta`` attribute.
+    """
     dat, info = chandra_models.get_data(
-        CHANDRA_MODELS_PITCH_ROLL_FILE, read_func=read_func
+        CHANDRA_MODELS_PITCH_ROLL_FILE, read_func=_roll_table_read_func
     )
     dat.meta.update(info)
-
-    # Sanity check that the pitch values are monotonically increasing. Duplicate values
-    # are allowed and np.interp will choose the second one in this case.
-    assert np.all(np.diff(dat["pitch"]) >= 0)
 
     return dat
 
 
-ROLL_TABLE = LazyVal(load_roll_table)
-
-
-def allowed_rolldev(pitch):
+def allowed_rolldev(pitch, roll_table=None):
     """Get allowed roll deviation (off-nominal roll) for the given ``pitch``.
 
     This performs a linear interpolation of the values in the pitch/roll table in
@@ -48,13 +63,18 @@ def allowed_rolldev(pitch):
 
     :param pitch: float, ndarray
         Sun pitch angle (deg)
+    :param roll_table: astropy.table.Table
+        Table of pitch/roll values (optional)
     :returns: float, ndarray
         Roll deviation (deg)
     """
+    if roll_table is None:
+        roll_table = load_roll_table()
+
     out = np.interp(
         x=pitch,
-        xp=ROLL_TABLE.val["pitch"],
-        fp=ROLL_TABLE.val["off_nom_roll"],
+        xp=roll_table["pitch"],
+        fp=roll_table["off_nom_roll"],
         left=-1.0,
         right=-1.0,
     )

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -27,8 +27,9 @@ def load_roll_table():
     )
     dat.meta.update(info)
 
-    # Sanity check that the pitch values are monotonically increasing.
-    assert np.all(np.diff(dat["pitch"]) > 0)
+    # Sanity check that the pitch values are monotonically increasing. Duplicate values
+    # are allowed and np.interp will choose the second one in this case.
+    assert np.all(np.diff(dat["pitch"]) >= 0)
 
     return dat
 

--- a/ska_sun/tests/test_sun.py
+++ b/ska_sun/tests/test_sun.py
@@ -1,22 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import contextlib
-
 import numpy as np
-import pytest
 from Quaternion import Quat
-from ska_helpers.utils import LazyVal
 
-import ska_sun.sun
-from ska_sun.sun import (
+import ska_sun
+from ska_sun import (
     allowed_rolldev,
     apply_sun_pitch_yaw,
     get_sun_pitch_yaw,
     nominal_roll,
     off_nominal_roll,
 )
-from ska_sun.sun import pitch as sun_pitch
-from ska_sun.sun import position
+from ska_sun import pitch as sun_pitch
+from ska_sun import position
 
 # Expected pitch, rolldev pairs
 exp_pitch_rolldev = np.array(
@@ -39,35 +35,20 @@ exp_pitch_rolldev = np.array(
 )
 
 
-@contextlib.contextmanager
-def clear_roll_table_lazy_val():
-    """Context manager to ensure the ROLL_TABLE LazyVal global is cleared before and
-    after the test.
-
-    This is needed to change the chandra_models version. Kinda yucky but there is no
-    convenient way to do this otherwise."""
-    if hasattr(ska_sun.sun.ROLL_TABLE, "_val"):
-        ska_sun.sun.ROLL_TABLE = LazyVal(ska_sun.sun.load_roll_table)
-    yield
-    if hasattr(ska_sun.sun.ROLL_TABLE, "_val"):
-        ska_sun.sun.ROLL_TABLE = LazyVal(ska_sun.sun.load_roll_table)
+def test_allowed_rolldev_with_roll_table(monkeypatch):
+    """Test computing scalar values with explicit roll table"""
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+    roll_table = ska_sun.load_roll_table()
+    for pitch, rolldev in exp_pitch_rolldev:
+        assert np.isclose(allowed_rolldev(pitch, roll_table), rolldev)
 
 
-@pytest.mark.parametrize("pitch, rolldev", exp_pitch_rolldev)
-def test_allowed_rolldev(pitch, rolldev, monkeypatch):
-    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.49")
-    # Test array of pitchs and allowed roll dev
-    with clear_roll_table_lazy_val():
-        assert np.isclose(allowed_rolldev(pitch), rolldev)
-
-
-def test_allowed_rolldev_vector(monkeypatch):
-    # Force reload of roll table
-    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.49")
-    with clear_roll_table_lazy_val():
-        assert np.allclose(
-            allowed_rolldev(exp_pitch_rolldev[:, 0]), exp_pitch_rolldev[:, 1]
-        )
+def test_allowed_rolldev_vector_without_roll_table(monkeypatch):
+    """Test passing a vector input and NO explicit roll table"""
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+    assert np.allclose(
+        allowed_rolldev(exp_pitch_rolldev[:, 0]), exp_pitch_rolldev[:, 1]
+    )
 
 
 def test_duplicate_pitch_rolldev(monkeypatch):
@@ -76,9 +57,13 @@ def test_duplicate_pitch_rolldev(monkeypatch):
     # duplicate pitch values, including pitch=85.5 with 12.436 and 17.5 roll dev vals.
     # The test is to make sure that the code handles this.
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "68670fc")
-    with clear_roll_table_lazy_val():
-        assert np.isclose(allowed_rolldev(85.5), 17.5, rtol=0, atol=1e-6)
-        assert np.isclose(allowed_rolldev(85.5 - 1e-10), 12.436, rtol=0, atol=1e-6)
+    assert np.isclose(allowed_rolldev(85.5), 17.5, rtol=0, atol=1e-6)
+    assert np.isclose(allowed_rolldev(85.5 - 1e-8), 12.436, rtol=0, atol=1e-6)
+    roll_table = ska_sun.load_roll_table()
+    pitch_min = roll_table["pitch"][0]
+    assert np.isclose(allowed_rolldev(pitch_min - 1e-8), -1.0, rtol=0, atol=1e-6)
+    pitch_max = roll_table["pitch"][-1]
+    assert np.isclose(allowed_rolldev(pitch_max + 1e-8), -1.0, rtol=0, atol=1e-6)
 
 
 def test_position():
@@ -154,9 +139,8 @@ def test_get_sun_pitch_yaw():
 
 
 def test_roll_table_meta():
-    from ska_sun.sun import ROLL_TABLE
-
     # A sampling of args from the roll table meta
+    roll_table = ska_sun.load_roll_table()
     exp = {
         "file_path": "chandra_models/pitch_roll/pitch_roll_constraint.csv",
         "version": None,
@@ -165,4 +149,12 @@ def test_roll_table_meta():
         "timeout": 5,
     }
     for key, val in exp.items():
-        assert ROLL_TABLE.val.meta["call_args"][key] == val
+        assert roll_table.meta["call_args"][key] == val
+
+
+def test_roll_table_pitch_increasing():
+    """Check that the pitch values are monotonically increasing. Duplicate values
+    are allowed and np.interp will choose the second one in this case.
+    """
+    dat = ska_sun.load_roll_table()
+    assert np.all(np.diff(dat["pitch"]) >= 0)

--- a/ska_sun/tests/test_sun.py
+++ b/ska_sun/tests/test_sun.py
@@ -36,12 +36,14 @@ exp_pitch_rolldev = np.array(
 
 
 @pytest.mark.parametrize("pitch, rolldev", exp_pitch_rolldev)
-def test_allowed_rolldev(pitch, rolldev):
+def test_allowed_rolldev(pitch, rolldev, monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.49")
     # Test array of pitchs and allowed roll dev
     assert np.isclose(allowed_rolldev(pitch), rolldev)
 
 
-def test_allowed_rolldev_vector():
+def test_allowed_rolldev_vector(monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.49")
     assert np.allclose(
         allowed_rolldev(exp_pitch_rolldev[:, 0]), exp_pitch_rolldev[:, 1]
     )

--- a/ska_sun/tests/test_sun.py
+++ b/ska_sun/tests/test_sun.py
@@ -1,9 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import contextlib
+
 import numpy as np
 import pytest
 from Quaternion import Quat
+from ska_helpers.utils import LazyVal
 
+import ska_sun.sun
 from ska_sun.sun import (
     allowed_rolldev,
     apply_sun_pitch_yaw,
@@ -35,18 +39,46 @@ exp_pitch_rolldev = np.array(
 )
 
 
+@contextlib.contextmanager
+def clear_roll_table_lazy_val():
+    """Context manager to ensure the ROLL_TABLE LazyVal global is cleared before and
+    after the test.
+
+    This is needed to change the chandra_models version. Kinda yucky but there is no
+    convenient way to do this otherwise."""
+    if hasattr(ska_sun.sun.ROLL_TABLE, "_val"):
+        ska_sun.sun.ROLL_TABLE = LazyVal(ska_sun.sun.load_roll_table)
+    yield
+    if hasattr(ska_sun.sun.ROLL_TABLE, "_val"):
+        ska_sun.sun.ROLL_TABLE = LazyVal(ska_sun.sun.load_roll_table)
+
+
 @pytest.mark.parametrize("pitch, rolldev", exp_pitch_rolldev)
 def test_allowed_rolldev(pitch, rolldev, monkeypatch):
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.49")
     # Test array of pitchs and allowed roll dev
-    assert np.isclose(allowed_rolldev(pitch), rolldev)
+    with clear_roll_table_lazy_val():
+        assert np.isclose(allowed_rolldev(pitch), rolldev)
 
 
 def test_allowed_rolldev_vector(monkeypatch):
+    # Force reload of roll table
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.49")
-    assert np.allclose(
-        allowed_rolldev(exp_pitch_rolldev[:, 0]), exp_pitch_rolldev[:, 1]
-    )
+    with clear_roll_table_lazy_val():
+        assert np.allclose(
+            allowed_rolldev(exp_pitch_rolldev[:, 0]), exp_pitch_rolldev[:, 1]
+        )
+
+
+def test_duplicate_pitch_rolldev(monkeypatch):
+    # This is a commit of the 2023_020 pitch/roll constraint file that is exactly what
+    # was provided by the FOT (except adding the header columns). It contains several
+    # duplicate pitch values, including pitch=85.5 with 12.436 and 17.5 roll dev vals.
+    # The test is to make sure that the code handles this.
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "68670fc")
+    with clear_roll_table_lazy_val():
+        assert np.isclose(allowed_rolldev(85.5), 17.5, rtol=0, atol=1e-6)
+        assert np.isclose(allowed_rolldev(85.5 - 1e-10), 12.436, rtol=0, atol=1e-6)
 
 
 def test_position():


### PR DESCRIPTION
## Description

This removes an unnecessary restriction in the chandra_models pitch/roll constraint file that the pitch values are strictly increasing. Instead the values need to increase or be constant. This works with numpy interpolation just fine.

In addition this uses a new mechanism from `ska_helpers` (https://github.com/sot/ska_helpers/pull/36) to allow caching in this context. With this the regression unit tests were updated to run at specified version of `chandra_models`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
The global `ROLL_TABLE` `LazyVal` has been removed. This was never intended as a public value and searching the `sot` org shows no code that uses it.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
With the following environment setup:
- Using an environment with https://github.com/sot/ska_helpers/pull/36 installed
- `CHANDRA_MODELS_REPO_DIR=/Users/aldcroft/git/chandra_models`, where that git repo is checked out at version 3.49 (consistent with master at this time).

<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Timing. Interesting `allowed_rolldev` got a factor of 4 faster, maybe due to using a smaller table?

#### This branch
```
In [1]: from ska_sun import allowed_rolldev

In [2]: %time allowed_rolldev(90.0)
CPU times: user 18.3 ms, sys: 21.1 ms, total: 39.4 ms
Wall time: 66.7 ms
Out[2]: 17.5

In [3]: %time allowed_rolldev(90.0)
CPU times: user 65 µs, sys: 6 µs, total: 71 µs
Wall time: 75.1 µs
Out[3]: 17.5

In [4]: %timeit allowed_rolldev(90.0)
7.99 µs ± 451 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
#### Flight 2023.1
```
In [1]: from ska_sun import allowed_rolldev

In [2]: %time allowed_rolldev(90.0)
CPU times: user 8 ms, sys: 1.34 ms, total: 9.34 ms
Wall time: 9.38 ms
Out[2]: 18.748772

In [3]: %time allowed_rolldev(90.0)
CPU times: user 152 µs, sys: 12 µs, total: 164 µs
Wall time: 158 µs
Out[3]: 18.748772

In [4]: %timeit allowed_rolldev(90.0)
38 µs ± 374 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

