### PR TITLE
Use an lru_cache when fetching the roll table

### DIFF
--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -14,6 +14,7 @@ from Chandra.Time import DateTime
 from chandra_aca.transform import radec_to_eci
 from Quaternion import Quat
 from ska_helpers import chandra_models
+import ska_helpers.paths
 
 
 @functools.lru_cache()
@@ -37,7 +38,7 @@ def _get_roll_table(repo_dir, version):
 
 
 def get_roll_table():
-    repo_dir = os.environ.get("CHANDRA_MODELS_REPO_DIR")
+    repo_dir = ska_helpers.paths.chandra_models_repo_path()
     version = os.environ.get("CHANDRA_MODELS_DEFAULT_VERSION")
     return _get_roll_table(repo_dir, version=version)
 


### PR DESCRIPTION
## Description
Use an lru_cache when fetching the roll table.  This makes the caching robust and flexible to changes in CHANDRA_MODELS_REPO_DIR (or SKA if that isn't defined) and CHANDRA_MODELS_DEFAULT_VERSION.  Though overall this dependence on those vars suggest to me that perhaps this belongs as a feature in ska_helpers.chandra_models.get_data itself.

This is a PR against #32 -  just extending Tom's idea about the lru_cache; though I made it cache on the vars - I guess equivalently one could use the tempdir or the commit sha as the lru cache key / arg?

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [X] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
