### PR TITLE
Set to use nominal roll range 0-360

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
     - id: black
 

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -401,7 +401,7 @@ def _nominal_roll(ra, dec, sun_ra, sun_dec):
     roll = np.degrees(np.arctan2(body_y[2], body_z[2]))
 
     # Convert to 0-360 range (arctan2 is -pi to pi)
-    roll = (roll + 360) % 360
+    roll = roll % 360
 
     return roll
 

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -377,7 +377,7 @@ def nominal_roll(ra, dec, time=None, sun_ra=None, sun_dec=None):
     :param sun_ra: Sun right ascension (instead of ``time``)
     :param sun_dec: Sun declination (instead of ``time``)
 
-    :returns: nominal roll angle (deg)
+    :returns: nominal roll angle (deg) in 0-360 range
 
     """
     if time is not None:
@@ -399,6 +399,10 @@ def _nominal_roll(ra, dec, sun_ra, sun_dec):
         np.sum(body_z**2)
     )  # shouldn't be needed but do it anyway
     roll = np.degrees(np.arctan2(body_y[2], body_z[2]))
+
+    # Convert to 0-360 range (arctan2 is -pi to pi)
+    roll = (roll + 360) % 360
+
     return roll
 
 

--- a/ska_sun/tests/test_sun.py
+++ b/ska_sun/tests/test_sun.py
@@ -121,6 +121,11 @@ def test_nominal_roll():
     assert np.allclose(roll, 68.83020)  # vs. 68.80 for obsid 12393 in JAN1711A
 
 
+def test_nominal_roll_range():
+    roll = nominal_roll(0, 89.9, time="2019:006:12:00:00")
+    assert np.allclose(roll, 287.24879)  # range in 0-360 and value for sparkles test
+
+
 def test_off_nominal_roll_and_pitch():
     att = (198.392135, 36.594359, 33.983322)  # RA, Dec, Roll of obsid 16354
     oroll = off_nominal_roll(att, "2015:335:00:00:00")  # NOT the 16354 time


### PR DESCRIPTION
## Description
Set to use nominal roll range 0-360

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This restores the behavior before #25 

## Interface impacts
Changes nominal roll range back to 0-360 from -180 to 180.  Unlikely to be impacting for downstream use, but impacts a sparkles test.
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Added new unit test.  Confirmed that sparkles tests (including test_roll_options_dec89_9) pass against this PR.
