### PR TITLE
Add functions get_att_for_sun_pitch_yaw() and get_nsm_attitude()

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,9 @@ project = 'ska_sun'
 copyright = '2020, Tom Aldcroft'
 author = 'Tom Aldcroft'
 
+# Disable showing type annotations
+autodoc_typehints = 'none'
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -50,7 +50,9 @@ def load_roll_table():
     - ``CHANDRA_MODELS_REPO_DIR``: root directory of chandra_models repo
     - ``CHANDRA_MODELS_DEFAULT_VERSION``: default version of chandra_models to use
 
-    :returns: ``astropy.table.Table``
+    Returns
+    -------
+    astropy.table.Table
         Table with "pitch" and "off_nom_roll" columns. Detailed provenance information
         is available in the table ``meta`` attribute.
     """
@@ -71,11 +73,16 @@ def allowed_rolldev(pitch, roll_table=None):
     For pitch values outside the range of the table the returned rolldev is -1.0,
     corresonding to a pitch angle outside of the planning limits.
 
-    :param pitch: float, ndarray
+    Parameters
+    ----------
+    pitch : float, ndarray
         Sun pitch angle (deg)
-    :param roll_table: astropy.table.Table
+    roll_table : astropy.table.Table
         Table of pitch/roll values (optional)
-    :returns: float, ndarray
+
+    Returns
+    -------
+    float, ndarray
         Roll deviation (deg)
     """
     if roll_table is None:
@@ -424,9 +431,16 @@ def _radec2eci(ra, dec):
 
     This is a numba-ized version of the original code in Ska.quatutil.
 
-    :param ra: Right Ascension (float, degrees)
-    :param dec: Declination (float, degrees)
-    :returns: numpy array ECI (3-vector)
+    Parameters
+    ----------
+    ra : float
+        Right Ascension (degrees)
+    dec : float
+        Declination (degrees)
+
+    Returns
+    -------
+    numpy array ECI (3-vector)
     """
     r = np.radians(ra)
     d = np.radians(dec)
@@ -579,21 +593,27 @@ def get_sun_pitch_yaw(
       >>> get_sun_pitch_yaw(att1.ra, att1.dec, time="2024:036:02:10:00")
       (90.97070080025568, 171.81963428481384)
 
-    :param ra: float, ndarray
-        RA(s)
-    :param dec: float, ndarray
-        Dec(s)
-    :param time: date-like, optional
+    Parameters
+    ----------
+    ra : float, ndarray
+        RA(s), degrees
+    dec : float, ndarray
+        Dec(s), degrees
+    time : date-like, optional
         Date of observation.
-    :param sun_ra: float, optional
+    sun_ra : float, optional
         RA of sun.  If not given, use estimated sun RA at ``date``.
-    :param sun_dec: float, optional
+    sun_dec : float, optional
         Dec of sun.  If not given, use estimated sun dec at ``date``.
-    :param coord_system: str, optional
+    coord_system : str, optional
         Coordinate system for yaw ("spacecraft" | "ORviewer", default="spacecraft").
 
-    :returns:
-        2-tuple (pitch, yaw) in degrees.
+    Returns
+    -------
+    pitch : float, ndarray
+        Sun pitch angle(s) in degrees.
+    yaw : float, ndarray
+        Sun yaw angle(s) in degrees.
     """
     # If not provided calculate sun RA and Dec using a low-accuracy ephemeris
     if sun_ra is None or sun_dec is None:
@@ -652,22 +672,26 @@ def apply_sun_pitch_yaw(
       >>> att1_apply.equatorial
       array([111.44329433, -71.34681456, 335.48326522])
 
-    :param att: Quaternion-like
+    Parameters
+    ----------
+    att : Quaternion-like
         Attitude(s) to be rotated.
-    :param pitch: float, ndarray
+    pitch : float, ndarray
         Sun pitch offsets (deg)
-    :param yaw: float, ndarray
+    yaw : float, ndarray
         Sun yaw offsets (deg)
-    :param time: CxoTimeLike, optional
+    time : CxoTimeLike, optional
         Time for sun position.
-    :param sun_ra: float, optional
+    sun_ra : float, optional
         RA of sun.  If not given, use estimated sun RA at ``time``.
-    :param sun_dec: float, optional
+    sun_dec : float, optional
         Dec of sun.  If not given, use estimated sun dec at ``time``.
-    :param coord_system: str, optional
+    coord_system : str, optional
         Coordinate system for yaw ("spacecraft" | "ORviewer", default="spacecraft").
 
-    :returns: Quat
+    Returns
+    -------
+    Quat
         Modified attitude(s)
     """
 
@@ -721,11 +745,11 @@ def get_att_for_sun_pitch_yaw(
     sun_dec: float | None = None,
     coord_system: str = "spacecraft",
     off_nom_roll: float = 0,
-):
+) -> Quat:
     """Get sun-pointed attitude for given sun pitch and yaw angles.
 
     This function is the inverse of ``get_sun_pitch_yaw()``, where the attitude is
-    constrained to have a nominal roll angle.
+    constrained to have the specified ``off_nom_roll`` angle (default=0).
 
     Parameters
     ----------

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -717,7 +717,8 @@ def get_att_for_sun_pitch_yaw(
     time: CxoTimeLike = None,
     sun_ra: float | None = None,
     sun_dec: float | None = None,
-    coord_system="spacecraft",
+    coord_system: str = "spacecraft",
+    off_nom_roll: float = 0,
 ):
     """Get sun-pointed attitude for given sun pitch and yaw angles.
 
@@ -728,11 +729,11 @@ def get_att_for_sun_pitch_yaw(
     if sun_ra is None or sun_dec is None:
         sun_ra, sun_dec = position(time)
 
-    # Generate a sun-pointed attitude pointed at the north ecliptic pole. Since the sun
-    # is near the ecliptic plane this never has numerical problems and pitch0 is around
-    # 90 degress. Then apply the appropriate pitch and yaw offsets to get to the desired
-    # sun pitch and yaw.
-    roll = nominal_roll(0, 90, sun_ra=sun_ra, sun_dec=sun_dec)
+    # Generate an attitude pointed at the north ecliptic pole. Since the sun is near the
+    # ecliptic plane this never has numerical problems and pitch0 is around 90 degress.
+    # Then apply the appropriate pitch and yaw offsets to get to the desired sun pitch
+    # and yaw.
+    roll = nominal_roll(0, 90, sun_ra=sun_ra, sun_dec=sun_dec) + off_nom_roll
     att0 = Quat([0, 90, roll])
     pitch0, yaw0 = get_sun_pitch_yaw(
         att0.ra, att0.dec, sun_ra=sun_ra, sun_dec=sun_dec, coord_system=coord_system

--- a/ska_sun/sun.py
+++ b/ska_sun/sun.py
@@ -823,7 +823,7 @@ def get_nsm_attitude(att: QuatLike, time: CxoTimeLike, pitch: float = 90) -> Qua
     Quat
         NSM attitude quaternion.
     """
-    # Calc Chanrda - sun vector in ECI (ignore CXO orbit)
+    # Calc Chandra - sun vector in ECI (ignore CXO orbit)
     (sun_ra, sun_dec) = position(time)
     sun_eci = np.array(_radec2eci(sun_ra, sun_dec))
 

--- a/ska_sun/tests/test_sun.py
+++ b/ska_sun/tests/test_sun.py
@@ -285,5 +285,5 @@ def test_array_input_and_different_formats(method):
 
     for ra, dec, time in zip(pos1[0], pos1[1], times):
         ra2, dec2 = ska_sun.position(time, method=method)
-        assert ra == ra2
-        assert dec == dec2
+        assert np.isclose(ra, ra2, rtol=0, atol=1e-13)
+        assert np.isclose(dec, dec2, rtol=0, atol=1e-13)


### PR DESCRIPTION
## Description

This adds a new convenience function `get_att_for_sun_pitch_yaw()` which is roughly the inverse of `get_sun_pitch_yaw()`, namely return an attitude with the specified sun pitch, yaw, and off_nom_roll .

It also migrates `chandra_maneuver.NSM_attitude()` to a function here `get_nsm_attitude()`, adding the option to specify the offset `pitch` angle.

### Additional changes

#### time / sun_ra / sun_dec

While in the code, I noticed a logical flaw in the handling of `time`, `sun_ra` and `sun_dec` in a few functions. The original logic was:
```
    # If ``time`` is provided then that is used to compute the sun position. Otherwise
    # ``sun_ra`` and ``sun_dec`` must be provided.
    if time is not None:
        sun_ra, sun_dec = position(time, method=method)
    roll = _nominal_roll(ra, dec, sun_ra, sun_dec)
```
The problem is that the user could supply `time=None` (meaning NOW) which satisfies "providing a time", but this would leave `sun_ra=None` and `sun_dec=None` and cause a confusing exception in `numba`.

The more robust logic is:
```
    # If both ``sun_ra`` and ``sun_dec`` are provided then those are used for the Sun
    # position; otherwise ``time`` is used to compute the Sun position.
    if sun_ra is None or sun_dec is None:
        sun_ra, sun_dec = position(time, method=method)
    roll = _nominal_roll(ra, dec, sun_ra, sun_dec)
```
This won't ever fail and adheres to the broad idea that not providing a time implies NOW. Note: in some cases the code was already doing this but the docstring was wrong.

#### Docs

The docs have been converted to numpydoc format and generally improved.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  ska_sun git:(get-att-from-sun-pitch-yaw) git rev-parse HEAD           
5d90ce880d6bea29326515165558ec7574da57d2
(ska3) ➜  ska_sun git:(get-att-from-sun-pitch-yaw) pytest
======================================================= test session starts ========================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 29 items                                                                                                                 

ska_sun/tests/test_sun.py .............................                                                                      [100%]

======================================================== 29 passed in 2.11s ========================================================
```
Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
5d90ce880d6bea29326515165558ec7574da57d2
ska3-jeanconn-fido> pytest -vs
================================================ test session starts ================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /proj/sot/ska3/flight/bin/python3.11
cachedir: .pytest_cache
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 29 items                                                                                                  

ska_sun/tests/test_sun.py::test_allowed_rolldev_with_roll_table PASSED
ska_sun/tests/test_sun.py::test_allowed_rolldev_vector_without_roll_table PASSED
ska_sun/tests/test_sun.py::test_duplicate_pitch_rolldev PASSED
ska_sun/tests/test_sun.py::test_position PASSED
ska_sun/tests/test_sun.py::test_position_diff_methods PASSED
ska_sun/tests/test_sun.py::test_nominal_roll PASSED
ska_sun/tests/test_sun.py::test_nominal_roll_range PASSED
ska_sun/tests/test_sun.py::test_off_nominal_roll_and_pitch PASSED
ska_sun/tests/test_sun.py::test_apply_get_sun_pitch_yaw[spacecraft] PASSED
ska_sun/tests/test_sun.py::test_apply_get_sun_pitch_yaw[ORviewer] PASSED
ska_sun/tests/test_sun.py::test_apply_sun_pitch_yaw[spacecraft] PASSED
ska_sun/tests/test_sun.py::test_apply_sun_pitch_yaw[ORviewer] PASSED
ska_sun/tests/test_sun.py::test_apply_sun_pitch_yaw_with_grid PASSED
ska_sun/tests/test_sun.py::test_get_sun_pitch_yaw PASSED
ska_sun/tests/test_sun.py::test_apply_get_sun_pitch_yaw_spacecraft_sign PASSED
ska_sun/tests/test_sun.py::test_roll_table_meta PASSED
ska_sun/tests/test_sun.py::test_roll_table_pitch_increasing PASSED
ska_sun/tests/test_sun.py::test_array_input_and_different_formats[fast] PASSED
ska_sun/tests/test_sun.py::test_array_input_and_different_formats[accurate] PASSED
ska_sun/tests/test_sun.py::test_nsm_attitude_random_atts[90] PASSED
ska_sun/tests/test_sun.py::test_nsm_attitude_random_atts[130] PASSED
ska_sun/tests/test_sun.py::test_nsm_attitude_random_atts[160] PASSED
ska_sun/tests/test_sun.py::test_nsm_attitude_corner_case PASSED
ska_sun/tests/test_sun.py::test_get_att_for_sun_pitch_yaw[spacecraft-True] PASSED
ska_sun/tests/test_sun.py::test_get_att_for_sun_pitch_yaw[spacecraft-False] PASSED
ska_sun/tests/test_sun.py::test_get_att_for_sun_pitch_yaw[ORviewer-True] PASSED
ska_sun/tests/test_sun.py::test_get_att_for_sun_pitch_yaw[ORviewer-False] PASSED
ska_sun/tests/test_sun.py::test_get_att_for_sun_pitch_yaw[None-True] PASSED
ska_sun/tests/test_sun.py::test_get_att_for_sun_pitch_yaw[None-False] PASSED

================================================ 29 passed in 16.80s
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
